### PR TITLE
Mitaka Support for QLogic SRIOV Fuel plugin

### DIFF
--- a/etc/default_data.json
+++ b/etc/default_data.json
@@ -3134,6 +3134,7 @@
             "releases": [
                 "Kilo",
                 "Liberty"
+		"Mitaka"
             ]
         },
         {


### PR DESCRIPTION
Update default_data.json file for QLogic SRIOV Fuel plugin with Adding Mitaka Release Support